### PR TITLE
Add Option For Custom Span Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ fun HtmlText(
     URLSpanStyle: SpanStyle = SpanStyle(
         color = linkTextColor(),
         textDecoration = TextDecoration.Underline
-    )
+    ),
+    customSpannedHandler: ((Spanned) -> AnnotatedString)? = null,
+    useCustomSpannedHandler: Boolean = customSpannedHandler != null
 )
 ```
 

--- a/htmlcompose/src/main/java/com/ireward/htmlcompose/HtmlText.kt
+++ b/htmlcompose/src/main/java/com/ireward/htmlcompose/HtmlText.kt
@@ -1,5 +1,6 @@
 package com.ireward.htmlcompose
 
+import android.text.Spanned
 import android.text.style.*
 import android.widget.TextView
 import androidx.compose.foundation.text.ClickableText
@@ -8,10 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.TextLayoutResult
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.*
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.TextUnit
@@ -35,9 +33,11 @@ fun HtmlText(
     URLSpanStyle: SpanStyle = SpanStyle(
         color = linkTextColor(),
         textDecoration = TextDecoration.Underline
-    )
+    ),
+    customSpannedHandler: ((Spanned) -> AnnotatedString)? = null,
+    useCustomSpannedHandler: Boolean = customSpannedHandler != null
 ) {
-    val content = text.asHTML(fontSize, flags, URLSpanStyle)
+    val content = text.asHTML(fontSize, flags, URLSpanStyle, customSpannedHandler, useCustomSpannedHandler)
     if (linkClicked != null) {
         ClickableText(
             modifier = modifier,
@@ -77,12 +77,18 @@ private fun linkTextColor() = Color(
 private fun String.asHTML(
     fontSize: TextUnit,
     flags: Int,
-    URLSpanStyle: SpanStyle
+    URLSpanStyle: SpanStyle,
+    customSpannedHandler: ((Spanned) -> AnnotatedString)? = null,
+    useCustomSpannedHandler: Boolean = customSpannedHandler != null
 ) = buildAnnotatedString {
     val spanned = HtmlCompat.fromHtml(this@asHTML, flags)
     val spans = spanned.getSpans(0, spanned.length, Any::class.java)
 
-    append(spanned.toString())
+    if (useCustomSpannedHandler) {
+        append(customSpannedHandler!!(spanned))
+    } else {
+        append(spanned.toString())
+    }
 
     spans
         .filter { it !is BulletSpan }


### PR DESCRIPTION
This adds the ability for adding custom spans in addition to the HTML styles. For example, I intent to use this to also include text highlighting for queries.