### PR TITLE
add onClicked parameter to HtmlText

### DIFF
--- a/app/src/main/java/com/ireward/showcase/MainActivity.kt
+++ b/app/src/main/java/com/ireward/showcase/MainActivity.kt
@@ -6,10 +6,10 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.text.Html
+import android.text.method.LinkMovementMethod
 import android.view.Gravity
-import android.view.ViewGroup
-import android.widget.LinearLayout
 import android.widget.TextView
+import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.Image
@@ -164,22 +164,24 @@ private fun AndroidLegacyTextView(html: String) {
     ) {
         AndroidView(
             modifier = Modifier
-                .fillMaxWidth()
                 .align(Alignment.Center)
                 .padding(10.dp),
             factory = { ctx ->
                 TextView(ctx).apply {
-                    layoutParams = LinearLayout.LayoutParams(
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.WRAP_CONTENT
-                    )
-
                     gravity = Gravity.CENTER
                     setLinkTextColor(ContextCompat.getColorStateList(context, R.color.blue))
                     text = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                         Html.fromHtml(html, Html.FROM_HTML_MODE_COMPACT)
                     } else {
                         Html.fromHtml(html)
+                    }
+                    movementMethod = LinkMovementMethod.getInstance()
+                    setOnClickListener {
+                        Toast.makeText(
+                            context,
+                            context.getText(R.string.textview_link_clicked_message),
+                            Toast.LENGTH_LONG
+                        ).show()
                     }
                 }
             })
@@ -219,6 +221,13 @@ private fun HtmlTextItem(context: Context, html: String) {
                         data = Uri.parse(link)
                     }
                 )
+            },
+            onClicked = {
+                Toast.makeText(
+                    context,
+                    context.getText(R.string.html_text_clicked_message),
+                    Toast.LENGTH_LONG
+                ).show()
             },
             URLSpanStyle = SpanStyle(
                 color = colorResource(id = R.color.blue),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">HTMLText</string>
+    <string name="textview_link_clicked_message">TextView without link clicked</string>
+    <string name="html_text_clicked_message">HtmlText without link clicked</string>
 </resources>

--- a/htmlcompose/src/main/java/com/ireward/htmlcompose/HtmlText.kt
+++ b/htmlcompose/src/main/java/com/ireward/htmlcompose/HtmlText.kt
@@ -30,6 +30,7 @@ fun HtmlText(
     maxLines: Int = Int.MAX_VALUE,
     onTextLayout: (TextLayoutResult) -> Unit = {},
     linkClicked: ((String) -> Unit)? = null,
+    onClicked: (() -> Unit)? = null,
     fontSize: TextUnit = 14.sp,
     flags: Int = HtmlCompat.FROM_HTML_MODE_COMPACT,
     URLSpanStyle: SpanStyle = SpanStyle(
@@ -52,6 +53,7 @@ fun HtmlText(
                     .getStringAnnotations(URL_TAG, it, it)
                     .firstOrNull()
                     ?.let { stringAnnotation -> linkClicked(stringAnnotation.item) }
+                    ?: onClicked?.invoke()
             }
         )
     } else {


### PR DESCRIPTION
* adds new parameter to HtmlText composable to handle when non-linked text is clicked
* in example app:
  * adds Toasts to TextView and HtmlText to demonstrate new functionality
  * adds movementMethod to TextView clickable links work
  * removes layoutParams from TextView, as it doesn't seem to do anything
  * removes fillMaxWidth, from AndroidView containing TextView so that text doesn't take up entire width, to match the layout of the HtmlText